### PR TITLE
inserir completed como pago

### DIFF
--- a/routes/paghiper/notification.js
+++ b/routes/paghiper/notification.js
@@ -87,6 +87,9 @@ module.exports = appSdk => {
               // https://atendimento.paghiper.com/hc/pt-br/articles/360016177713
               status = 'authorized'
               break
+            case 'completed':
+              status = 'paid'
+              break
 
             default:
               // ignore unknow status


### PR DESCRIPTION
Na loja Coisas da Teca, muitos pedidos estão sendo aprovados após o vencimento permitido pelo paghiper. Ela tendo que alterar manual, após o cliente acusar.
Nesse caso, quando der completado, tem que ser utilizado, mesmo que coloque como pago.

No corpo está assim:

    {
      "date_time": "2020-10-01T12:01:18.593Z",
      "status": "paid",
      "notification_code": "5NP4E9S2N3ETEHB4YOT5C5ADDO3004Q5SG96P28D5M7K3JO27I7JOIX161265TCX",
      "customer_notified": true,
      "_id": "5f75c50e7430f92180f73c44",
      "flags": [
        "cpm-skip",
        "cpm:patch"
      ]
    },
    {
      "date_time": "2020-10-01T16:50:29.693Z",
      "status": "authorized",
      "notification_code": "RYNFY4CNKAR8EFCP8SQZK7FDVPYYEHV6FJLENX178TGN8TDHM3G6BVK7LI50Z16F",
      "customer_notified": true,
      "_id": "5f7608d57430f92180f76313",
      "flags": [
        "cpm-skip",
        "cpm:patch"
      ]
    }
Porém, de acordo com a teca no paghiper autorizado foi dia 30, o status dia 1 foi o status pago e dia 3 o completado.
Diferente do json que ficou só o autorizado.